### PR TITLE
version number synced to rubocop version

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -28,10 +28,10 @@ Documentation:
 Style/BarePercentLiterals:
   EnforcedStyle: percent_q
 
-Style/EmptyLineBetweenDefs:
+Layout/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: true
 
-Style/MultilineOperationIndentation:
+Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 
 Style/StringLiterals:
@@ -61,14 +61,6 @@ Style/ParallelAssignment:
 Style/Lambda:
   Enabled: false
 
-#not appliable for rails<5
-Rails/HttpPositionalArguments:
-  Enabled: false
-
-#not appliable for ruby<2.4
-Lint/UnifiedInteger:
-  Enabled: false
-
 Rails/SkipsModelValidations:
   Enabled: false
 
@@ -77,7 +69,6 @@ Style/SafeNavigation:
 
 Bundler/OrderedGems:
   Enabled: false
-
 
 Metrics/LineLength:
   Max: 100
@@ -88,7 +79,6 @@ Metrics/ClassLength:
 Metrics/ModuleLength:
   Max: 150
 
-
 Lint/EndAlignment:
   EnforcedStyleAlignWith: variable
 
@@ -98,3 +88,13 @@ Lint/AssignmentInCondition:
 Lint/AmbiguousRegexpLiteral:
   Exclude:
     - 'features/step_definitions/**/*.rb'
+
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - "spec/**/*"
+
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%i': '()'
+    '%w': '()'
+    '%W': '()'

--- a/lib/sanelint/version.rb
+++ b/lib/sanelint/version.rb
@@ -1,3 +1,3 @@
 module Sanelint
-  VERSION = "49.1".freeze
+  VERSION = "1.49.1".freeze
 end

--- a/lib/sanelint/version.rb
+++ b/lib/sanelint/version.rb
@@ -1,3 +1,3 @@
 module Sanelint
-  VERSION = "1.0.2".freeze
+  VERSION = "49.1".freeze
 end

--- a/sanelint.gemspec
+++ b/sanelint.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rubocop", "~> 0.47.0"
-  spec.add_runtime_dependency "rubocop-rspec", "~> 1.13.0"
+  spec.add_runtime_dependency "rubocop", "~> 0.49.1"
+  spec.add_runtime_dependency "rubocop-rspec", "~> 1.16.0"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
The idea is to have a sanelint for every rubocop version. As version 1 was already present we decided to incerement rubocop major version by 1 while keeping minor versioning, thus rubocop 0.49.1 corresponds to sanelint 1.49.1

`PercentLiteralDelimiters` was updated to force parentheses over square brackets