### PR TITLE
Update rubocop, rubocop-rspec, bundler and rake

### DIFF
--- a/lib/rubocop/sanelint/inject.rb
+++ b/lib/rubocop/sanelint/inject.rb
@@ -7,7 +7,7 @@ module RuboCop
     # bit of our configuration.
     module Inject
       DEFAULT_FILE = File.expand_path(
-        '../../../../config/default.yml', __FILE__
+        "../../../../config/default.yml", __FILE__
       )
 
       def self.defaults!

--- a/lib/sanelint/version.rb
+++ b/lib/sanelint/version.rb
@@ -1,3 +1,3 @@
 module Sanelint
-  VERSION = "1.49.1".freeze
+  VERSION = "1.52.1".freeze
 end

--- a/sanelint.gemspec
+++ b/sanelint.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
-  spec.executables   = spec.files.rgep(%r{^exe/}) { |f| File.basename(f) }
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "rubocop", "~> 0.52.1"

--- a/sanelint.gemspec
+++ b/sanelint.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'sanelint/version'
+require "sanelint/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "sanelint"
@@ -15,12 +15,12 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.executables   = spec.files.rgep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rubocop", "~> 0.49.1"
-  spec.add_runtime_dependency "rubocop-rspec", "~> 1.16.0"
+  spec.add_runtime_dependency "rubocop", "~> 0.52.1"
+  spec.add_runtime_dependency "rubocop-rspec", "~> 1.22.2"
 
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "rake", "~> 12.3"
 end


### PR DESCRIPTION
New ruby 2.5 was released, we need new rubocop.
Why not update all the dependencies?

Tested against local fresh (3 weeks) Rails project with ruby 2.5.