### PR TITLE
[chore] Update rules naming

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -46,7 +46,10 @@ Style/BracesAroundHashParameters:
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 Style/DoubleNegation:
@@ -79,7 +82,7 @@ Metrics/ClassLength:
 Metrics/ModuleLength:
   Max: 150
 
-Lint/EndAlignment:
+Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 
 Lint/AssignmentInCondition:

--- a/lib/sanelint/version.rb
+++ b/lib/sanelint/version.rb
@@ -1,3 +1,3 @@
 module Sanelint
-  VERSION = "1.52.1".freeze
+  VERSION = "1.61.1".freeze
 end

--- a/sanelint.gemspec
+++ b/sanelint.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rubocop", "~> 0.52.1"
-  spec.add_runtime_dependency "rubocop-rspec", "~> 1.22.2"
+  spec.add_runtime_dependency "rubocop", "~> 0.61.1"
+  spec.add_runtime_dependency "rubocop-rspec", "~> 1.30.1"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.3"


### PR DESCRIPTION
Some of rubocop's rules have been renamed and
it is now reflected in Sanelint.

Update rubocop and rubocop-rspec versions.